### PR TITLE
SR-3516 : Trigger nudge in a corner case to avoid hanging in the buffering state

### DIFF
--- a/lib/media/stream.js
+++ b/lib/media/stream.js
@@ -618,7 +618,7 @@ shaka.media.Stream.prototype.onUpdate_ = function() {
           this.timestampCorrection_ = timestampCorrection;
         }
 
-        if (this.needsNudge_ && this.sbm_.bufferedAheadOf(currentTime) > 0) {
+        if (this.needsNudge_ && (this.video_.currentTime <= shaka.media.Stream.NUDGE_ || this.sbm_.bufferedAheadOf(currentTime) > 0)) {
           shaka.log.debug(this.logPrefix_(), 'applying nudge...');
           this.needsNudge_ = false;
           this.video_.currentTime += shaka.media.Stream.NUDGE_;
@@ -788,4 +788,3 @@ shaka.media.Stream.createAdaptationEvent_ = function(streamInfo) {
   });
   return event;
 };
-

--- a/lib/media/stream.js
+++ b/lib/media/stream.js
@@ -617,8 +617,9 @@ shaka.media.Stream.prototype.onUpdate_ = function() {
           shaka.asserts.assert(timestampCorrection != null);
           this.timestampCorrection_ = timestampCorrection;
         }
-
-        if (this.needsNudge_ && (this.video_.currentTime <= shaka.media.Stream.NUDGE_ || this.sbm_.bufferedAheadOf(currentTime) > 0)) {
+        // SR-3516: Enure the nudge is triggered when jumping back to 0s which is out of MSE buffered range.
+        // 0.01s should be safe as it's just about one video frame.
+        if (this.needsNudge_ && (this.video_.currentTime <= 0.01 || this.sbm_.bufferedAheadOf(currentTime) > 0)) {
           shaka.log.debug(this.logPrefix_(), 'applying nudge...');
           this.needsNudge_ = false;
           this.video_.currentTime += shaka.media.Stream.NUDGE_;


### PR DESCRIPTION
- When starting at 120s and then jumping back to 0s directly, for example, bufferedAheadOf() seems to return 0 so nudge will not be triggered.
