### PR TITLE
Enable withCredentials for XHR when userId cookie exists

### DIFF
--- a/fork.md
+++ b/fork.md
@@ -157,16 +157,3 @@ This is needed for overriding adaptive bitrate. Appears to be a miss in the orig
 There are three configuration settings outside shaka-player are related to this. When enableWithCredentialsOnHTTPAndMatchedCookie is set to true, new RegExp(enableWithCredentialsOnHTTPAndMatchedCookieRegExpString, enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption) will be further checked against document.cookie before setting shaka.util.AjaxRequest.enableWithCredentialsOnHTTP to true in shaka-player. shaka.util.FailoverUri.prototype.isHttp will be checked too before setting withCredentials to true in XHR eventually.
 
 NOTE : A wildcard '\*' cannot be used in the 'Access-Control-Allow-Origin' header when the credentials flag is true.
-
-Full example of configuration outside shaka-player:
-
-```Javascript
-videoEngine: {
-        dash: {
-            shaka: {
-                enableWithCredentialsOnHTTPAndMatchedCookie: true,
-                enableWithCredentialsOnHTTPAndMatchedCookieRegExpString: '(^|;)\s*userId=',
-                enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption: ''
-            }
-        }
-```

--- a/fork.md
+++ b/fork.md
@@ -154,9 +154,11 @@ This is needed for overriding adaptive bitrate. Appears to be a miss in the orig
 
 ### Make withCredentials for XHR configurable
 
-There are three configuration settings related to this. When enableWithCredentialsOnHTTPAndMatchedCookie is set to true, new RegExp(enableWithCredentialsOnHTTPAndMatchedCookieRegExpString, enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption) will be further checked against document.cookies before setting withCredentials to true. It's currently applicable to HTTP only.
+There are three configuration settings outside shaka-player are related to this. When enableWithCredentialsOnHTTPAndMatchedCookie is set to true, new RegExp(enableWithCredentialsOnHTTPAndMatchedCookieRegExpString, enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption) will be further checked against document.cookie before setting shaka.util.AjaxRequest.enableWithCredentialsOnHTTP to true in shaka-player. shaka.util.FailoverUri.prototype.isHttp will be checked too before setting withCredentials to true in XHR eventually.
 
-Full example:
+NOTE : A wildcard '\*' cannot be used in the 'Access-Control-Allow-Origin' header when the credentials flag is true.
+
+Full example of configuration outside shaka-player:
 
 ```Javascript
 videoEngine: {

--- a/fork.md
+++ b/fork.md
@@ -17,12 +17,13 @@ Based on version 1.6.5 of the original repo.
 * Handle 403s or 404s as "end of live stream"
 * suggestedPresentationDelay attribute for live streams also respected in segment timeline manifests
 * Demo page convenience additions
+* Make withCredentials for XHR configurable via player configuration
 
 ### Build scripts for including customizations
 
 Variations on build.sh and all.sh are added, [build-vup-debug](https://github.com/vimond/shaka-player/blob/manifestmodifier/build/build-vup-debug.sh),  [lib-vup-debug.sh](https://github.com/vimond/shaka-player/blob/manifestmodifier/build/lib-vup-debug.sh), and [all-vup-debug.sh](https://github.com/vimond/shaka-player/blob/manifestmodifier/build/all-vup-debug.sh).
 
-For including the Vimond extensions, use 
+For including the Vimond extensions, use
 ```Shell
 ./build/all-vup-debug.sh
 ```
@@ -89,9 +90,9 @@ To be documented later.
 
 ### Exposing a stream position's start date/time
 
-Live stream positions are reported as a number of seconds relative to a starting point. This isn't necessarily the start of the seekable range, due to different DVR characteristics. 
+Live stream positions are reported as a number of seconds relative to a starting point. This isn't necessarily the start of the seekable range, due to different DVR characteristics.
 
-Instead they are offset to the DASH manifest's `availabilityStartTime` attribute. 
+Instead they are offset to the DASH manifest's `availabilityStartTime` attribute.
 
 In order to be able to map stream positions to dates and wall clock times, the `availabilityStartTime` date/time is exposed through a callback function.
 
@@ -150,3 +151,20 @@ This is needed for overriding adaptive bitrate. Appears to be a miss in the orig
 
 * Configuration text area that can parse a JSON string and apply it as the ManifestModificationSetup parameter mentioned above.
 * Last used stream and license URLs are remembered.
+
+### Make withCredentials for XHR configurable
+
+There are three configuration settings related to this. When enableWithCredentialsOnHTTPAndMatchedCookie is set to true, new RegExp(enableWithCredentialsOnHTTPAndMatchedCookieRegExpString, enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption) will be further checked against document.cookies before setting withCredentials to true. It's currently applicable to HTTP only.
+
+Full example:
+
+```JSON
+videoEngine: {
+        dash: {
+            shaka: {
+                enableWithCredentialsOnHTTPAndMatchedCookie: true,
+                enableWithCredentialsOnHTTPAndMatchedCookieRegExpString: '(^|;)\s*userId=',
+                enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption: ''
+            }
+        }
+```

--- a/fork.md
+++ b/fork.md
@@ -158,7 +158,7 @@ There are three configuration settings related to this. When enableWithCredentia
 
 Full example:
 
-```JSON
+```Javascript
 videoEngine: {
         dash: {
             shaka: {

--- a/lib/media/source_buffer_manager.js
+++ b/lib/media/source_buffer_manager.js
@@ -275,7 +275,6 @@ shaka.media.SourceBufferManager.prototype.fetch = function(
         params.contentDatabase = this.contentDatabase_;
         var enableWithCredentialsOnHTTP = shaka.util.AjaxRequest.enableWithCredentialsOnHTTP;
         if (enableWithCredentialsOnHTTP && reference.url.isHttp) {
-          console.log('params.withCredentials = true');
           params.withCredentials = true;
         }
         return [

--- a/lib/media/source_buffer_manager.js
+++ b/lib/media/source_buffer_manager.js
@@ -273,13 +273,10 @@ shaka.media.SourceBufferManager.prototype.fetch = function(
         params.baseRetryDelayMs = refDuration * 1000;
         params.requestTimeoutMs = this.segmentRequestTimeout_ * 1000;
         params.contentDatabase = this.contentDatabase_;
-        var enableWithCredentialsOnHTTPAndMatchedCookie = shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookie;
-        if (enableWithCredentialsOnHTTPAndMatchedCookie && reference.url.isHttp) {
-          var matchedCookieRegExpString = shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpString;
-          var matchedCookieRegExpOption = shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption;
-          if (new RegExp(matchedCookieRegExpString, matchedCookieRegExpOption).test(document.cookie)) {
-            params.withCredentials = true;
-          }
+        var enableWithCredentialsOnHTTP = shaka.util.AjaxRequest.enableWithCredentialsOnHTTP;
+        if (enableWithCredentialsOnHTTP && reference.url.isHttp) {
+          console.log('params.withCredentials = true');
+          params.withCredentials = true;
         }
         return [
           reference.url.fetch(params, this.estimator_),

--- a/lib/media/source_buffer_manager.js
+++ b/lib/media/source_buffer_manager.js
@@ -273,6 +273,11 @@ shaka.media.SourceBufferManager.prototype.fetch = function(
         params.baseRetryDelayMs = refDuration * 1000;
         params.requestTimeoutMs = this.segmentRequestTimeout_ * 1000;
         params.contentDatabase = this.contentDatabase_;
+        // Vimond Edit
+        if (/(^|;)\s*userId=/.test(document.cookie)) {
+          params.withCredentials = true;
+        }
+        // Vimond Edit
         return [
           reference.url.fetch(params, this.estimator_),
           shaka.util.FailoverUri.prototype.abortFetch.bind(reference.url)];
@@ -671,4 +676,3 @@ if (!COMPILED) {
     return 'SBM ' + this.mimeType_ + ':';
   };
 }
-

--- a/lib/media/source_buffer_manager.js
+++ b/lib/media/source_buffer_manager.js
@@ -273,11 +273,14 @@ shaka.media.SourceBufferManager.prototype.fetch = function(
         params.baseRetryDelayMs = refDuration * 1000;
         params.requestTimeoutMs = this.segmentRequestTimeout_ * 1000;
         params.contentDatabase = this.contentDatabase_;
-        // Vimond Edit
-        if (/(^|;)\s*userId=/.test(document.cookie)) {
-          params.withCredentials = true;
+        var enableWithCredentialsOnHTTPAndMatchedCookie = shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookie;
+        if (enableWithCredentialsOnHTTPAndMatchedCookie && reference.url.isHttp) {
+          var matchedCookieRegExpString = shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpString;
+          var matchedCookieRegExpOption = shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption;
+          if (new RegExp(matchedCookieRegExpString, matchedCookieRegExpOption).test(document.cookie)) {
+            params.withCredentials = true;
+          }
         }
-        // Vimond Edit
         return [
           reference.url.fetch(params, this.estimator_),
           shaka.util.FailoverUri.prototype.abortFetch.bind(reference.url)];

--- a/lib/player/player.js
+++ b/lib/player/player.js
@@ -105,7 +105,7 @@ shaka.player.Player = function(video) {
 
   /** @private {boolean} */
   this.buffering_ = false;
-  
+
   /** @private {boolean} */
   this.liveShutdownOnError_ = false;
 
@@ -398,7 +398,7 @@ shaka.player.Player.prototype.setVideoEventListeners_ = function() {
 shaka.player.Player.prototype.onSourceError_ = function(evt) {
   if (evt.detail && 'net' == evt.detail.type && !evt.detail.isStartup && this.videoSource_.isLive() && (404 == evt.detail.status || 403 == evt.detail.status)) {
     shaka.log.info('404 or 403 on live stream. Shutting down.');
-    
+
     this.unload();
     var event = shaka.util.FakeEvent.create({type: 'ended' });
     this.dispatchEvent(event);
@@ -431,7 +431,7 @@ shaka.player.Player.prototype.onError_ = function(event) {
     shaka.log.debug('Uninterpretable error event!', event);
     return;
   }
-  
+
   var code = this.video_.error.code;
   if (code == MediaError['MEDIA_ERR_ABORTED']) {
     // Ignore this error code, which should only occur when navigating away or
@@ -821,6 +821,16 @@ shaka.player.Player.prototype.configure = function(config) {
       'disableCacheBustingEvenThoughItMayAffectBandwidthEstimation');
   if (disableCacheBusting != null) {
     shaka.util.AjaxRequest.enableCacheBusting = !disableCacheBusting;
+  }
+
+  var enableWithCredentialsOnHTTPAndMatchedCookie = MapUtils.getBoolean(config,
+      'enableWithCredentialsOnHTTPAndMatchedCookie');
+  if (enableWithCredentialsOnHTTPAndMatchedCookie) {
+    shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookie = enableWithCredentialsOnHTTPAndMatchedCookie;
+    var enableWithCredentialsOnHTTPAndMatchedCookieRegExpString = MapUtils.getString(config, 'enableWithCredentialsOnHTTPAndMatchedCookieRegExpString');
+    var enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption = MapUtils.getString(config, 'enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption');
+    shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpString = enableWithCredentialsOnHTTPAndMatchedCookieRegExpString;
+    shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption = enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption;
   }
 
   var shutdownOnLiveError = MapUtils.getBoolean(config,

--- a/lib/player/player.js
+++ b/lib/player/player.js
@@ -823,14 +823,10 @@ shaka.player.Player.prototype.configure = function(config) {
     shaka.util.AjaxRequest.enableCacheBusting = !disableCacheBusting;
   }
 
-  var enableWithCredentialsOnHTTPAndMatchedCookie = MapUtils.getBoolean(config,
-      'enableWithCredentialsOnHTTPAndMatchedCookie');
-  if (enableWithCredentialsOnHTTPAndMatchedCookie) {
-    shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookie = enableWithCredentialsOnHTTPAndMatchedCookie;
-    var enableWithCredentialsOnHTTPAndMatchedCookieRegExpString = MapUtils.getString(config, 'enableWithCredentialsOnHTTPAndMatchedCookieRegExpString');
-    var enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption = MapUtils.getString(config, 'enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption');
-    shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpString = enableWithCredentialsOnHTTPAndMatchedCookieRegExpString;
-    shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption = enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption;
+  var enableWithCredentialsOnHTTP = MapUtils.getBoolean(config,
+      'enableWithCredentialsOnHTTP');
+  if (enableWithCredentialsOnHTTP) {
+    shaka.util.AjaxRequest.enableWithCredentialsOnHTTP = enableWithCredentialsOnHTTP;
   }
 
   var shutdownOnLiveError = MapUtils.getBoolean(config,

--- a/lib/util/ajax_request.js
+++ b/lib/util/ajax_request.js
@@ -186,6 +186,21 @@ shaka.util.AjaxRequest.Parameters = function() {
 /** @type {boolean} */
 shaka.util.AjaxRequest.enableCacheBusting = true;
 
+/**
+ * Whether withCredentials should be enabled conditionally.
+ * When enabled, new RegExp(enableWithCredentialsOnHTTPAndMatchedCookieRegExpString,
+ * enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption) will be further checked
+ * against document.cookies before setting withCredentials to true.
+ *
+ * @type {boolean}
+ */
+shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookie = false;
+
+/** @type {string|null} */
+shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpString = null;
+
+/** @type {string|null} */
+shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption = null;
 
 /**
  * Destroys the AJAX request.

--- a/lib/util/ajax_request.js
+++ b/lib/util/ajax_request.js
@@ -187,20 +187,11 @@ shaka.util.AjaxRequest.Parameters = function() {
 shaka.util.AjaxRequest.enableCacheBusting = true;
 
 /**
- * Whether withCredentials should be enabled conditionally.
- * When enabled, new RegExp(enableWithCredentialsOnHTTPAndMatchedCookieRegExpString,
- * enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption) will be further checked
- * against document.cookies before setting withCredentials to true.
+ * Whether withCredentials should be enabled on http.
  *
  * @type {boolean}
  */
-shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookie = false;
-
-/** @type {string|null} */
-shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpString = null;
-
-/** @type {string|null} */
-shaka.util.AjaxRequest.enableWithCredentialsOnHTTPAndMatchedCookieRegExpOption = null;
+shaka.util.AjaxRequest.enableWithCredentialsOnHTTP = false;
 
 /**
  * Destroys the AJAX request.

--- a/lib/util/failover_uri.js
+++ b/lib/util/failover_uri.js
@@ -102,6 +102,17 @@ shaka.util.FailoverUri.prototype.isOfflineUri = function() {
 
 
 /**
+ * Gets whether the URI is http.
+ *
+ * @return {boolean}
+ */
+shaka.util.FailoverUri.prototype.isHttp = function() {
+  // Offline does not use failover.
+  return this.urls[0].getScheme() == 'http';
+};
+
+
+/**
  * Gets the data specified by the URLs.
  *
  * @param {shaka.util.AjaxRequest.Parameters=} opt_parameters
@@ -223,4 +234,3 @@ shaka.util.FailoverUri.prototype.clone = function() {
 shaka.util.FailoverUri.prototype.toString = function() {
   return this.urls[0].toString();
 };
-


### PR DESCRIPTION
- This should only apply to fetching segments (which should hopefully
  be equivalent to the original customization in dash.js).
- withCredentials for XHR is set to false by default.
- Do we need to make it further configurable from UniPlayer SDK somehow?
