### PR TITLE
Remove a few seconds of source buffer when QuotaExceededError occurred

### DIFF
--- a/fork.md
+++ b/fork.md
@@ -18,6 +18,7 @@ Based on version 1.6.5 of the original repo.
 * suggestedPresentationDelay attribute for live streams also respected in segment timeline manifests
 * Demo page convenience additions
 * Make withCredentials for XHR configurable via player configuration
+* Remove a few seconds (controlled by `shaka.player.Defaults.REMOVE_BUFFER_SIZE_AT_QUOTAEXCEPTIONERROR`) of source buffer when QuotaExceededError occurred
 
 ### Build scripts for including customizations
 

--- a/lib/media/source_buffer_manager.js
+++ b/lib/media/source_buffer_manager.js
@@ -537,7 +537,16 @@ shaka.media.SourceBufferManager.prototype.append_ = function(data) {
     // This will trigger an 'updateend' event.
     this.sourceBuffer_.appendBuffer(data);
   } catch (exception) {
-    return Promise.reject(exception);
+    shaka.log.error(
+        this.logPrefix_(),
+        'QuotaExceededError occurred:',
+        'Tried to remove a few secs of sourceBuffer to recover.');
+
+    var removeStart = this.sourceBuffer_.buffered.start(0);
+    var removeEnd = removeStart + shaka.player.Defaults.REMOVE_BUFFER_SIZE_AT_QUOTAEXCEPTIONERROR;
+    this.sourceBuffer_.remove(removeStart, removeEnd);
+    // Avoid rejecting the Promise so that it has a chance to recover.
+    //return Promise.reject(exception);
   }
 
   this.operationPromise_ = new shaka.util.PublicPromise();
@@ -671,4 +680,3 @@ if (!COMPILED) {
     return 'SBM ' + this.mimeType_ + ':';
   };
 }
-

--- a/lib/player/defaults.js
+++ b/lib/player/defaults.js
@@ -36,6 +36,16 @@ shaka.player.Defaults.STREAM_BUFFER_SIZE = 15;
 
 
 /**
+ * The amount of source buffer from the beginning, in seconds, that should be
+ * removed when QuotaExceededError occurred in appendBuffer()
+ *
+ * @const {number}
+ * @exportDoc
+ */
+shaka.player.Defaults.REMOVE_BUFFER_SIZE_AT_QUOTAEXCEPTIONERROR = 5;
+
+
+/**
  * The license request timeout in seconds. A value of zero indicates no timeout.
  *
  * @const {number}
@@ -71,4 +81,3 @@ shaka.player.Defaults.SEGMENT_REQUEST_TIMEOUT = 0;
  * @exportDoc
  */
 shaka.player.Defaults.PREFERRED_LANGUAGE = 'en';
-


### PR DESCRIPTION
- Add a default setting to control the amount of source buffer to
  remove.
- Note that the actual amount of buffer being removed will depend on
  the source buffer fragmentation.
