### PR TITLE
IFLIX-2221: 'timeupdate' event can be triggered after player destruction

### DIFF
--- a/lib/player/player.js
+++ b/lib/player/player.js
@@ -420,7 +420,10 @@ shaka.player.Player.prototype.onSourceError_ = function(evt) {
 shaka.player.Player.prototype.onFirstTimestamp_ = function(event) {
   shaka.timer.end('load');
   this.stats_.logPlaybackLatency(shaka.timer.get('load'));
-  this.eventManager_.unlisten(this.video_, 'timeupdate');
+  if(this.eventManager_)
+    this.eventManager_.unlisten(this.video_, 'timeupdate');
+  else
+    shaka.log.debug('Unable to unlisten \'timeupdate\' Event from EventManager!', event);
 };
 
 


### PR DESCRIPTION
'timeupdate' event can be triggered after player is destroyed. Not reproducable, but shown by client's error statistics. Safe to ignore this error.